### PR TITLE
Fixes #3: cli compatibility changes relating to license keys and profiles

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,5 +18,5 @@ jobs:
         uses: ./
         with:
           accountId: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
-          insertApiKey: ${{ secrets.NEW_RELIC_INSERT_API_KEY }}
+          ingestLicenseKey: ${{ secrets.NEW_RELIC_INGEST_LICENSE_KEY }}
           testOutputPath: test-output/integration.xml

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Post JUnit test results to New Relic
-        uses: newrelic/junit-reporter-action@v2
+        uses: newrelic/junit-reporter-action@v0.2
         with:
           accountId: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
           ingestLicenseKey: ${{ secrets.NEW_RELIC_INGEST_LICENSE_KEY }}

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A GitHub Action to send JUnit test run results to New Relic.
 | ------------------- | -------- | ------- | ----------- |
 | `accountId`         | **yes**  | -       | The account to post test run results to. This could also be a subaccount. |
 | `region`            | no       | US      | The region the account belongs to. |
-| `insertApiKey` | **yes**  | -       | Your New Relic [Insert API key](https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#event-insert-key). |
+| `ingestLicenseKey` | **yes**  | -       | Your New Relic [License key](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/) used for data ingest. |
 | `testOutputPath`    | **yes**  | -       | The path to the JUnit output file. |
 
 ## Example usage
@@ -24,14 +24,15 @@ contents of the provided JUnit output file.
 
 Github secrets assumed to be set:
 * `NEW_RELIC_ACCOUNT_ID` - New Relic Account ID to post the event data to
-* `NEW_RELIC_INSERT_API_KEY` - Insert API key
-* `NEW_RELIC_APPLICATION_ID` - New Relic Application ID to create the marker on
+* `NEW_RELIC_INGEST_LICENSE_KEY` - New Relic Ingest License Key
 
 ```yaml
 name: Release
 
 on:
-  - release
+  push:
+    branches:
+        - main
 
 jobs:
   newrelic:
@@ -42,10 +43,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Post JUnit test results to New Relic
-        uses: newrelic/junit-reporter-action@v0.1
+        uses: newrelic/junit-reporter-action@v2
         with:
           accountId: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
-          insertApiKey: ${{ secrets.NEW_RELIC_INSERT_API_KEY }}
+          ingestLicenseKey: ${{ secrets.NEW_RELIC_INGEST_LICENSE_KEY }}
           testOutputPath: test-output/integration.xml
 ```
 

--- a/action.yaml
+++ b/action.yaml
@@ -5,8 +5,8 @@ branding:
   icon: 'upload-cloud'
   color: 'blue'
 inputs:
-  insertApiKey:
-    description: 'Your New Relic Insert API key.'
+  ingestLicenseKey:
+    description: 'Your New Relic Ingest License key.'
     required: true
   accountId:
     description: 'Your New Relic account ID. Custom events representing your test run will be posted to this account.'
@@ -22,7 +22,7 @@ runs:
   using: 'docker'
   image: 'Dockerfile'
   env:
-    NEW_RELIC_INSERT_API_KEY: ${{ inputs.insertApiKey }}
+    NEW_RELIC_INGEST_LICENSE_KEY: ${{ inputs.ingestLicenseKey }}
     NEW_RELIC_ACCOUNT_ID: ${{ inputs.accountId }}
     NEW_RELIC_REGION: ${{ inputs.region }}
     NEW_RELIC_TEST_OUTPUT_PATH: ${{ inputs.testOutputPath }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,12 @@
 #!/bin/sh
 
-export NEW_RELIC_API_KEY=dummy_key
-export NEW_RELIC_INSIGHTS_INSERT_KEY=${NEW_RELIC_INSERT_API_KEY}
+newrelic profiles add --profile githubActions \
+  --licenseKey ${NEW_RELIC_INGEST_LICENSE_KEY} \
+  --apiKey ${NEW_RELIC_INGEST_LICENSE_KEY} \
+  --region "${NEW_RELIC_REGION}" \
+  --accountId ${NEW_RELIC_ACCOUNT_ID}
+
+newrelic profile default --profile githubActions
 
 result=$(newrelic reporting junit \
   --accountId "${NEW_RELIC_ACCOUNT_ID}" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,12 +1,8 @@
 #!/bin/sh
 
-newrelic profiles add --profile githubActions \
-  --licenseKey ${NEW_RELIC_INGEST_LICENSE_KEY} \
-  --apiKey ${NEW_RELIC_INGEST_LICENSE_KEY} \
-  --region "${NEW_RELIC_REGION}" \
-  --accountId ${NEW_RELIC_ACCOUNT_ID}
-
-newrelic profile default --profile githubActions
+export NEW_RELIC_API_KEY=dummy_key
+export NEW_RELIC_REGION=${NEW_RELIC_REGION}
+export NEW_RELIC_LICENSE_KEY=${NEW_RELIC_INGEST_LICENSE_KEY}
 
 result=$(newrelic reporting junit \
   --accountId "${NEW_RELIC_ACCOUNT_ID}" \


### PR DESCRIPTION
This change sets up a New Relic auth profile, githubActions, and sets it as the default nr-cli profile using the specified license key and accountId. These changes should also shift the user to use the Ingest API keys over the no longer recommended Insights Insert Key. 